### PR TITLE
setup.cfg: Fix version reference

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gnumake_tokenpool
-version = attr: py.src.gnumake_tokenpool.tokenpool.__version__
+version = attr: gnumake_tokenpool.tokenpool.__version__
 author = Milan Hauth
 author_email = milahu@gmail.com
 description = jobclient and jobserver for the GNU make tokenpool protocol


### PR DESCRIPTION
This fixes the error on installation:
```
      ModuleNotFoundError: No module named 'py.src'
 ```
