### PR TITLE
Add option `use_cysignals`

### DIFF
--- a/py/src/gnumake_tokenpool/tokenpool.py
+++ b/py/src/gnumake_tokenpool/tokenpool.py
@@ -27,7 +27,7 @@ class JobClient:
       max_load: int or None = None,
       debug: bool or None = None,
       debug2: bool or None = None,
-      use_cysignals: bool = False,
+      use_cysignals: bool = None,
     ):
 
     self._fdRead = None
@@ -49,9 +49,14 @@ class JobClient:
     self._log = self._get_log(self._debug)
     self._log2 = self._get_log(self._debug2)
 
-    if use_cysignals:
-      from cysignals import changesignal
-      self._changesignal = changesignal
+    if use_cysignals is not False:
+      try:
+        from cysignals import changesignal
+      except ImportError:
+        if use_cysignals:
+          raise
+      else:
+        self._changesignal = changesignal
 
     makeFlags = os.environ.get("MAKEFLAGS", "")
     if makeFlags:

--- a/py/src/gnumake_tokenpool/tokenpool.py
+++ b/py/src/gnumake_tokenpool/tokenpool.py
@@ -51,11 +51,12 @@ class JobClient:
 
     if use_cysignals is not False:
       try:
-        from cysignals import changesignal
+        from cysignals.pysignals import changesignal
       except ImportError:
         if use_cysignals:
           raise
       else:
+        self._log("init: using cysignals.pysignals.changesignal")
         self._changesignal = changesignal
 
     makeFlags = os.environ.get("MAKEFLAGS", "")


### PR DESCRIPTION
SageMath uses https://github.com/sagemath/cysignals for advanced interrupt and signal handling with Cython modules.

We add an option `JobClient(use_cysignals=True)` (default: `False`). 
With the option set, it imports a context manager `changesignal` from `cysignals`, which replaces the use of the standard library function `signals.signal`.

This new option helps us solve https://github.com/sagemath/sage/issues/36944
