### PR TITLE
Clear fdReadDup if the dup'ed fd has been closed

### DIFF
--- a/py/src/gnumake_tokenpool/tokenpool.py
+++ b/py/src/gnumake_tokenpool/tokenpool.py
@@ -205,6 +205,7 @@ class JobClient:
       self._log(f"acquire: read timeout")
       assert self._fdReadDup
       os.close(self._fdReadDup)
+      self._fdReadDup = None
 
     # SIGALRM = timer has fired = read timeout
     with self._changesignal(signal.SIGALRM, read_timeout_handler):
@@ -236,8 +237,8 @@ class JobClient:
         signal.setitimer(signal.ITIMER_REAL, 0) # clear timer. unix only
 
     if len(buffer) == 0:
-      self._log(f"acquire: read failed: buffer is empty")
-      return None
+      # the only way to not read a byte is the timeout handler, which causes the OSError handled above
+      raise AssertionError('buffer cannot be empty without calling timeout handler')
 
     token = ord(buffer) # byte -> int8
     self._log(f"acquire: read ok. token = {token}")


### PR DESCRIPTION
It is normal for acquire to timeout and return None, so to definitely obtain a token one needs to loop until success:
```py
    jobClient = gnumake_tokenpool.JobClient()
    while True:
        token = jobClient.acquire()
        if token:
	    break

    # do some work

    jobClient.release(token)
```
However, the timeout handler in `acquire()` does not clear `self._fdReadDup`. So subsequent call do not `dup()` a new copy of the fd, and try to read from the already-closed fd. Effectively, this means that if the timeout was hit once then it behaves like the timeout hits immediatly in the subsequent calls.